### PR TITLE
Fix darwin arm64(m1 Mac) broken binary

### DIFF
--- a/hack/goreleaser-postbuild.sh
+++ b/hack/goreleaser-postbuild.sh
@@ -5,6 +5,11 @@ if [ $2 == "windows" ]; then
   exit 0
 fi
 
+if [ $1 == "rbac-tool_darwin_arm64" ]; then
+  echo "Skipping Running UPX on Darwin arm64 - $1"
+  exit 0
+fi
+
 echo "Running UPX - $1"
 find dist/$1* -type f -executable -exec ./bin/upx {} +
 


### PR DESCRIPTION
Because of [bug](https://github.com/upx/upx/issues/446) of upx on m1 Mac, we should skip upx post hook in goreleaser when build darwin arm64 binary. This can fix process killed problem in [issue](https://github.com/alcideio/rbac-tool/issues/34).