### PR TITLE
Don't add rules with an empty verbs list to the generated rbac rules

### DIFF
--- a/cmd/generate_cmd.go
+++ b/cmd/generate_cmd.go
@@ -170,7 +170,7 @@ func generateRules(clusterContext string, denyResources sets.String, includeGrou
 
 		var newPolicyRule *rbacv1.PolicyRule
 
-		if len(resourceList) == 0 {
+		if len(resourceList) == 0 || uniqueVerbs.Len() == 0 {
 			continue
 		}
 


### PR DESCRIPTION
Kubernetes does not allow an rbac rule to have an empty verbs list, if you try to apply this, it will fail:
```yaml
apiVersion: rbac.authorization.k8s.io/v1
kind: ClusterRole
metadata:
  name: brokenrole
rules:
- apiGroups:
  - ""
  resources:
  - "pods"
  verbs: []
```

like so

```
$ kubectl apply -f broken.yaml
The ClusterRole "brokenrole" is invalid: rules[0].verbs: Required value: verbs must contain at least one value
```

However in some cases `rbac-tool` can generate rules that contain these empty verbs list, for example when you pass an allowed verbs list that does not include the one the ressource responds to, for example, on a vanilla `kind` cluster:

```
$ rbac-tool gen --allowed-verbs get |& grep '\[\]'
  verbs: []
  verbs: []
```

This simple patch disallows adding to the pile a rule that has empty verbs. After the patch, on the same cluster:
```
$ ./bin/rbac-tool gen --allowed-verbs=get|& grep '\[\]'
# nothing
```