### PR TITLE
Make possible to use viz when no psps access

### DIFF
--- a/cmd/analysis_cmd.go
+++ b/cmd/analysis_cmd.go
@@ -57,7 +57,7 @@ rbac-tool analyze
 				return fmt.Errorf("Failed to create kubernetes client - %v", err)
 			}
 
-			perms, err := rbac.NewPermissionsFromCluster(client)
+			perms, err := rbac.NewPermissionsFromCluster(client, true)
 			if err != nil {
 				return err
 			}

--- a/cmd/lookup_cmd.go
+++ b/cmd/lookup_cmd.go
@@ -66,7 +66,7 @@ rbac-tool lookup -ne '^system:.*'
 				return fmt.Errorf("Failed to create kubernetes client - %v", err)
 			}
 
-			perms, err := rbac.NewPermissionsFromCluster(client)
+			perms, err := rbac.NewPermissionsFromCluster(client, true)
 			if err != nil {
 				return err
 			}

--- a/cmd/policyrules_cmd.go
+++ b/cmd/policyrules_cmd.go
@@ -6,9 +6,10 @@ import (
 	"fmt"
 	"os"
 	"regexp"
-	"sigs.k8s.io/yaml"
 	"sort"
 	"strings"
+
+	"sigs.k8s.io/yaml"
 
 	"github.com/alcideio/rbac-tool/pkg/kube"
 	"github.com/alcideio/rbac-tool/pkg/rbac"
@@ -74,7 +75,7 @@ rbac-tool policy-rules -o json  | jp "[? @.allowedTo[? (verb=='get' || verb=='*'
 				return fmt.Errorf("Failed to create kubernetes client - %v", err)
 			}
 
-			perms, err := rbac.NewPermissionsFromCluster(client)
+			perms, err := rbac.NewPermissionsFromCluster(client, true)
 			if err != nil {
 				return err
 			}

--- a/cmd/whocan_cmd.go
+++ b/cmd/whocan_cmd.go
@@ -143,7 +143,7 @@ rbac-tool who-can get secret/some-secret
 				return err
 			}
 
-			perms, err := rbac.NewPermissionsFromCluster(client)
+			perms, err := rbac.NewPermissionsFromCluster(client, true)
 			if err != nil {
 				return err
 			}

--- a/pkg/visualize/rbacviz.go
+++ b/pkg/visualize/rbacviz.go
@@ -69,7 +69,7 @@ func (r *RbacViz) initialize(opts *Opts) error {
 			return fmt.Errorf("Failed to create kubernetes client - %v", err)
 		}
 
-		perms, err := rbac.NewPermissionsFromCluster(client)
+		perms, err := rbac.NewPermissionsFromCluster(client, opts.ShowPSP)
 		if err != nil {
 			return err
 		}


### PR DESCRIPTION
In viz command don't collect pod security policy if showpsp=false on command line.

Now you can use viz even if you don't have ability to access psp.