### PR TITLE
Printing bash-completion to stdout and fixing typos in usage

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,7 +54,7 @@ Usage:
 Available Commands:
   analysis        Analyze RBAC permissions and highlight overly permissive principals, risky permissions, etc.
   auditgen        Generate RBAC policy from Kubernetes audit events
-  bash-completion Generate bash completion. source < (rbac-too bash-completion)
+  bash-completion Generate bash completion. source <(rbac-tool bash-completion)
   generate        Generate Role or ClusterRole and reduce the use of wildcards
   help            Help about any command
   lookup          RBAC Lookup by subject (user/group/serviceaccount) name

--- a/main.go
+++ b/main.go
@@ -20,12 +20,12 @@ func RbacGenCmd() *cobra.Command {
 
 	var genBashCompletionCmd = &cobra.Command{
 		Use:   "bash-completion",
-		Short: "Generate bash completion. source < (rbac-too bash-completion)",
-		Long:  "Generate bash completion. source < (rbac-too bash-completion)",
+		Short: "Generate bash completion. source <(rbac-tool bash-completion)",
+		Long:  "Generate bash completion. source <(rbac-tool bash-completion)",
 		Run: func(cmd *cobra.Command, args []string) {
 			out := new(bytes.Buffer)
 			_ = rootCmd.GenBashCompletion(out)
-			println(out.String())
+			fmt.Println(out.String())
 		},
 	}
 


### PR DESCRIPTION
`bash-completion` should be printed to `stdout` so it's easier to consume. The usage instructions for it also had typos.

Before:

```
> 2>/dev/null rbac-tool bash-completion | wc -l
0
```

After:

```
> 2>/dev/null bin/rbac-tool bash-completion | wc -l
766
```