### PR TITLE
Added functionality to fetch subresources

### DIFF
--- a/cmd/generate_cmd.go
+++ b/cmd/generate_cmd.go
@@ -118,8 +118,9 @@ func generateRules(clusterContext string, denyResources sets.String, includeGrou
 	computedPolicyRules := make([]rbacv1.PolicyRule, 0)
 
 	//processedGroups := sets.NewString()
+	_, apiResourceListArray, err := kubeClient.Client.DiscoveryClient.ServerGroupsAndResources()
 
-	for _, apiGroup := range kubeClient.ServerPreferredResources {
+	for _, apiGroup := range apiResourceListArray {
 
 		// rbac rules only look at API group names, not name + version
 		gv, err := schema.ParseGroupVersion(apiGroup.GroupVersion)


### PR DESCRIPTION
Added fetching subresources. The filtering mechanism is unchanged since the syntax is:
```
rbac-tool gen --deny-resources=clusterrolebindings.rbac.authorization.k8s.io,clusterroles.rbac.authorization.k8s.io,pods/exec. --allowed-verbs=get,list,watch
```