### PR TITLE
Add metadata flags for name, namespace and annotations

### DIFF
--- a/cmd/generate_cmd.go
+++ b/cmd/generate_cmd.go
@@ -101,6 +101,7 @@ func generateRole(generateKind string, rules []rbacv1.PolicyRule, name string, n
 			},
 			ObjectMeta: metav1.ObjectMeta{
 				Name: name,
+				Annotations: annotations,
 			},
 			Rules: rules,
 		}

--- a/cmd/show_permissions_cmd.go
+++ b/cmd/show_permissions_cmd.go
@@ -22,12 +22,15 @@ import (
 func NewCommandGenerateShowPermissions() *cobra.Command {
 
 	clusterContext := ""
+	name := "custom-role"
+	namespace := "myappnamespace"
 	generateKind := "ClusterRole"
 	forGroups := []string{"*"}
 	withVerb := []string{"*"}
 	scope := "cluster"
 	denyVerb := []string{}
 	denyResource := []string{}
+	annotations := map[string]string{}
 
 	// Support overrides
 	cmd := &cobra.Command{
@@ -87,7 +90,7 @@ rbac-tool show --scope=namespaced --without-verbs=create,update,patch,delete,del
 			if scope == "namespaced" {
 				generateKind = "Role"
 			}
-			obj, err := generateRole(generateKind, computedPolicyRules)
+			obj, err := generateRole(generateKind, computedPolicyRules, name, namespace, annotations)
 			if err != nil {
 				return err
 			}
@@ -100,12 +103,15 @@ rbac-tool show --scope=namespaced --without-verbs=create,update,patch,delete,del
 
 	flags := cmd.Flags()
 
-	flags.StringVarP(&clusterContext, "cluster-context", "c", "", "Cluster.use 'kubectl config get-contexts' to list available contexts")
+	flags.StringVarP(&clusterContext, "cluster-context", "c", "", "Cluster. Use 'kubectl config get-contexts' to list available contexts")
+	flags.StringVar(&name, "name", "", "Name of Role/ClusterRole")
+	flags.StringVarP(&namespace, "namespace", "n", "", "Namespace of Role/ClusterRole")
 	flags.StringVarP(&scope, "scope", "", "all", "Filter by resource scope. Valid values are: 'cluster' | 'namespaced' | 'all' ")
 	flags.StringSliceVar(&forGroups, "for-groups", []string{"*"}, "Comma separated list of API groups we would like to show the permissions")
 	flags.StringSliceVar(&withVerb, "with-verbs", []string{"*"}, "Comma separated list of verbs to include. To include all use '*'")
 	flags.StringSliceVar(&denyVerb, "without-verbs", []string{""}, "Comma separated list of verbs to exclude.")
 	flags.StringSliceVar(&denyResource, "without-resources", []string{""}, "Comma separated list of resources to exclude. Syntax: <resourceName>.<apiGroup>")
+	flags.StringToStringVar(&annotations, "annotations", map[string]string{}, "Custom annotations")
 
 	return cmd
 }


### PR DESCRIPTION
This pull request is in reference to the following issue:

https://github.com/alcideio/rbac-tool/issues/92

- Adds flag for `metadata.name` to `rbac-tool gen|show`
- Adds flag for `metadata.namespace` to `rbac-tool gen|show`
- Adds flag for `metadata.annotations` to `rbac-tool gen|show`
- Merges expanded rules back into individual APIGroups for readability