### PR TITLE
Optimize lookup match rules

### DIFF
--- a/README.md
+++ b/README.md
@@ -159,15 +159,21 @@ Examples:
 
 ```shell script
 # Search All Service Accounts
-rbac-tool lookup -e '.*'
+rbac-tool lookup
 ```
 
 ```shell script
-# Search All Service Accounts That Contains myname
+# Search Service Accounts that match myname exactly
+rbac-tool lookup myname
+```
+
+```shell script
+# Search All Service Accounts that contain myname
 rbac-tool lookup -e '.*myname.*'
 ```
 
 ```shell script
+# Lookup System Accounts (all accounts that start with system: )
 rbac-tool lookup -e '^system:'
   SUBJECT                                         | SUBJECT TYPE | SCOPE       | NAMESPACE   | ROLE                                                                 | BINDING
 +-------------------------------------------------+--------------+-------------+-------------+----------------------------------------------------------------------+---------------------------------------------------+

--- a/cmd/lookup_cmd.go
+++ b/cmd/lookup_cmd.go
@@ -51,7 +51,7 @@ rbac-tool lookup -ne '^system:.*'
 			var err error
 
 			if regex == "" {
-				if len(args) > 0 {
+				if len(args) == 1 {
 					// exact match
 					re, err = regexp.Compile(fmt.Sprintf(`^%v$`, args[0]))
 				} else {

--- a/cmd/lookup_cmd.go
+++ b/cmd/lookup_cmd.go
@@ -30,7 +30,10 @@ A Kubernetes RBAC lookup of Roles/ClusterRoles used by a given User/ServiceAccou
 Examples:
 
 # Search All Service Accounts
-rbac-tool lookup -e '.*'
+rbac-tool lookup
+
+# Search Service Accounts that match myname exactly
+rbac-tool lookup myname
 
 # Search All Service Accounts that contain myname
 rbac-tool lookup -e '.*myname.*'
@@ -47,14 +50,17 @@ rbac-tool lookup -ne '^system:.*'
 			var re *regexp.Regexp
 			var err error
 
-			if regex != "" {
-				re, err = regexp.Compile(regex)
-			} else {
-				if len(args) != 1 {
-					re, err = regexp.Compile(fmt.Sprintf(`.*`))
+			if regex == "" {
+				if len(args) > 0 {
+					// exact match
+					re, err = regexp.Compile(fmt.Sprintf(`^%v$`, args[0]))
 				} else {
-					re, err = regexp.Compile(fmt.Sprintf(`(?mi)%v`, args[0]))
+					// search all service accounts
+					re, err = regexp.Compile(fmt.Sprintf(`.*`))
 				}
+			} else {
+				// regex match
+				re, err = regexp.Compile(regex)
 			}
 
 			if err != nil {


### PR DESCRIPTION
Optimize match rules of the lookup command as follows:
- If the `-e` parameter is not specified, return service accounts that match exactly.
- If the `-e` parameter is specified, return service accounts that match regex.
- If no service account is provided for searching, return all service accounts.

For example:
```bash
rbac-tool lookup "kubelet"

# exact match
  SUBJECT | SUBJECT TYPE | SCOPE       | NAMESPACE | ROLE                                   | BINDING                                 
+---------+--------------+-------------+-----------+----------------------------------------+----------------------------------------+
  kubelet | User         | ClusterRole |           | system:node-problem-detector           | kubelet-user-npd-binding                
  kubelet | User         | ClusterRole |           | system:node-bootstrapper               | kubelet-bootstrap                       
  kubelet | User         | ClusterRole |           | gce:beta:kubelet-certificate-bootstrap | gce:beta:kubelet-certificate-bootstrap  
```

```bash
rbac-tool lookup -e "kubelet"

# regex match
  SUBJECT           | SUBJECT TYPE | SCOPE       | NAMESPACE | ROLE                                   | BINDING                                  
+-------------------+--------------+-------------+-----------+----------------------------------------+-----------------------------------------+
  kubelet           | User         | ClusterRole |           | gce:beta:kubelet-certificate-bootstrap | gce:beta:kubelet-certificate-bootstrap   
  kubelet           | User         | ClusterRole |           | system:node-bootstrapper               | kubelet-bootstrap                        
  kubelet           | User         | ClusterRole |           | system:node-problem-detector           | kubelet-user-npd-binding                 
  kubelet-bootstrap | User         | ClusterRole |           | gce:beta:kubelet-certificate-bootstrap | kubelet-bootstrap-certificate-bootstrap  
  kubelet-bootstrap | User         | ClusterRole |           | system:node-bootstrapper               | kubelet-bootstrap-node-bootstrapper  
```

```bash
rbac-tool lookup

# return all service accounts
 SUBJECT                               | SUBJECT TYPE   | SCOPE       | NAMESPACE                | ROLE                                                 | BINDING                                               
+---------------------------------------+----------------+-------------+--------------------------+------------------------------------------------------+------------------------------------------------------+
  antrea-controller                     | ServiceAccount | ClusterRole |                          | antrea-controller                                    | antrea-controller                                     
  antrea-cpha                           | ServiceAccount | ClusterRole |                          | antrea-cpha                                          | antrea-cpha                                           
  antrea-cpha                           | ServiceAccount | Role        | kube-system              | antrea-cpha                                          | antrea-cpha                                           
  attachdetach-controller               | ServiceAccount | ClusterRole |                          | system:controller:attachdetach-controller            | system:controller:attachdetach-controller             
  bootstrap-signer                      | ServiceAccount | Role        | kube-public              | system:controller:bootstrap-signer                   | system:controller:bootstrap-signer                    
  bootstrap-signer                      | ServiceAccount | Role        | kube-system              | system:controller:bootstrap-signer                   | system:controller:bootstrap-signer                    
  cert-controller-manager               | ServiceAccount | ClusterRole |                          | cert-controller-manager                              | cert-controller-manager                               
  cert-controller-manager               | ServiceAccount | Role        | gardener                 | cert-controller-manager                              | cert-controller-manager                               
  certificate-controller                | ServiceAccount | ClusterRole |                          | system:controller:certificate-controller             | system:controller:certificate-controller       
......
```