### PR TITLE
Add metadata flags

### DIFF
--- a/cmd/generate_cmd.go
+++ b/cmd/generate_cmd.go
@@ -22,8 +22,8 @@ import (
 func NewCommandGenerateClusterRole() *cobra.Command {
 
 	clusterContext := ""
-	name := "custom-cluster-role"
-	namespace := "myappnamespace"
+	name := ""
+	namespace := ""
 	generateKind := ""
 	allowedGroups := []string{}
 	//expandGroups := []string{}
@@ -79,8 +79,8 @@ rbac-tool gen --generated-type=ClusterRole --deny-resources=secrets., --allowed-
 
 	flags.StringVarP(&generateKind, "generated-type", "t", "ClusterRole", "Role or ClusterRole")
 	flags.StringVarP(&clusterContext, "cluster-context", "c", "", "Cluster.use 'kubectl config get-contexts' to list available contexts")
-	flags.StringVar(&name, "name", "", "Name of Role/ClusterRole")
-	flags.StringVarP(&namespace, "namespace", "n", "", "Namespace of Role/ClusterRole")
+	flags.StringVar(&name, "name", "custom-cluster-role", "Name of Role/ClusterRole")
+	flags.StringVarP(&namespace, "namespace", "n", "myappnamespace", "Namespace of Role/ClusterRole")
 	//flags.StringSliceVarP(&expandGroups, "expand-groups", "g", []string{""},  "Comma separated list of API groups we would like to list all resource kinds rather than using wild cards '*'")
 	flags.StringSliceVar(&allowedGroups, "allowed-groups", []string{"*"}, "Comma separated list of API groups we would like to allow '*'")
 	flags.StringSliceVar(&allowedVerb, "allowed-verbs", []string{"*"}, "Comma separated list of verbs to include. To include all use '*'")

--- a/cmd/generate_cmd.go
+++ b/cmd/generate_cmd.go
@@ -22,11 +22,14 @@ import (
 func NewCommandGenerateClusterRole() *cobra.Command {
 
 	clusterContext := ""
+	name := "custom-cluster-role"
+	namespace := "myappnamespace"
 	generateKind := ""
 	allowedGroups := []string{}
 	//expandGroups := []string{}
 	allowedVerb := []string{}
 	denyResources := []string{}
+	annotations := map[string]string{}
 
 	// Support overrides
 	cmd := &cobra.Command{
@@ -61,7 +64,7 @@ rbac-tool gen --generated-type=ClusterRole --deny-resources=secrets., --allowed-
 				return err
 			}
 
-			obj, err := generateRole(generateKind, computedPolicyRules)
+			obj, err := generateRole(generateKind, computedPolicyRules, name, namespace, annotations)
 			if err != nil {
 				return err
 			}
@@ -76,15 +79,18 @@ rbac-tool gen --generated-type=ClusterRole --deny-resources=secrets., --allowed-
 
 	flags.StringVarP(&generateKind, "generated-type", "t", "ClusterRole", "Role or ClusterRole")
 	flags.StringVarP(&clusterContext, "cluster-context", "c", "", "Cluster.use 'kubectl config get-contexts' to list available contexts")
+	flags.StringVar(&name, "name", "", "Name of Role/ClusterRole")
+	flags.StringVarP(&namespace, "namespace", "n", "", "Namespace of Role/ClusterRole")
 	//flags.StringSliceVarP(&expandGroups, "expand-groups", "g", []string{""},  "Comma separated list of API groups we would like to list all resource kinds rather than using wild cards '*'")
 	flags.StringSliceVar(&allowedGroups, "allowed-groups", []string{"*"}, "Comma separated list of API groups we would like to allow '*'")
 	flags.StringSliceVar(&allowedVerb, "allowed-verbs", []string{"*"}, "Comma separated list of verbs to include. To include all use '*'")
 	flags.StringSliceVar(&denyResources, "deny-resources", []string{""}, "Comma separated list of resource.group - for example secret. to deny secret (core group) access")
+	flags.StringToStringVar(&annotations, "annotations", map[string]string{}, "Custom annotations")
 
 	return cmd
 }
 
-func generateRole(generateKind string, rules []rbacv1.PolicyRule) (string, error) {
+func generateRole(generateKind string, rules []rbacv1.PolicyRule, name string, namespace string, annotations map[string]string) (string, error) {
 	var obj runtime.Object
 
 	if generateKind == "ClusterRole" {
@@ -94,19 +100,24 @@ func generateRole(generateKind string, rules []rbacv1.PolicyRule) (string, error
 				APIVersion: "rbac.authorization.k8s.io/v1",
 			},
 			ObjectMeta: metav1.ObjectMeta{
-				Name: "custom-cluster-role",
+				Name:        name,
+				Annotations: annotations,
 			},
 			Rules: rules,
 		}
 	} else {
+		if generateKind == "Role" && name == "custom-cluster-role" {
+			name = "cluster-role"
+		}
 		obj = &rbacv1.Role{
 			TypeMeta: metav1.TypeMeta{
 				Kind:       "Role",
 				APIVersion: "rbac.authorization.k8s.io/v1",
 			},
 			ObjectMeta: metav1.ObjectMeta{
-				Name:      "custom-role",
-				Namespace: "mynamespace",
+				Name:        name,
+				Namespace:   namespace,
+				Annotations: annotations,
 			},
 			Rules: rules,
 		}

--- a/cmd/show_permissions_cmd.go
+++ b/cmd/show_permissions_cmd.go
@@ -22,12 +22,15 @@ import (
 func NewCommandGenerateShowPermissions() *cobra.Command {
 
 	clusterContext := ""
+	name := "custom-cluster-role"
+	namespace := "myappnamespace"
 	generateKind := "ClusterRole"
 	forGroups := []string{"*"}
 	withVerb := []string{"*"}
 	scope := "cluster"
 	denyVerb := []string{}
 	denyResource := []string{}
+	annotations := map[string]string{}
 
 	// Support overrides
 	cmd := &cobra.Command{
@@ -87,7 +90,7 @@ rbac-tool show --scope=namespaced --without-verbs=create,update,patch,delete,del
 			if scope == "namespaced" {
 				generateKind = "Role"
 			}
-			obj, err := generateRole(generateKind, computedPolicyRules)
+			obj, err := generateRole(generateKind, computedPolicyRules, name, namespace, annotations)
 			if err != nil {
 				return err
 			}
@@ -101,11 +104,14 @@ rbac-tool show --scope=namespaced --without-verbs=create,update,patch,delete,del
 	flags := cmd.Flags()
 
 	flags.StringVarP(&clusterContext, "cluster-context", "c", "", "Cluster.use 'kubectl config get-contexts' to list available contexts")
+	flags.StringVar(&name, "name", "", "Name of Role/ClusterRole")
+	flags.StringVarP(&namespace, "namespace", "n", "", "Namespace of Role/ClusterRole")
 	flags.StringVarP(&scope, "scope", "", "all", "Filter by resource scope. Valid values are: 'cluster' | 'namespaced' | 'all' ")
 	flags.StringSliceVar(&forGroups, "for-groups", []string{"*"}, "Comma separated list of API groups we would like to show the permissions")
 	flags.StringSliceVar(&withVerb, "with-verbs", []string{"*"}, "Comma separated list of verbs to include. To include all use '*'")
 	flags.StringSliceVar(&denyVerb, "without-verbs", []string{""}, "Comma separated list of verbs to exclude.")
 	flags.StringSliceVar(&denyResource, "without-resources", []string{""}, "Comma separated list of resources to exclude. Syntax: <resourceName>.<apiGroup>")
+	flags.StringToStringVar(&annotations, "annotations", map[string]string{}, "Custom annotations")
 
 	return cmd
 }

--- a/cmd/show_permissions_cmd.go
+++ b/cmd/show_permissions_cmd.go
@@ -22,8 +22,8 @@ import (
 func NewCommandGenerateShowPermissions() *cobra.Command {
 
 	clusterContext := ""
-	name := "custom-cluster-role"
-	namespace := "myappnamespace"
+	name := ""
+	namespace := ""
 	generateKind := "ClusterRole"
 	forGroups := []string{"*"}
 	withVerb := []string{"*"}
@@ -104,8 +104,8 @@ rbac-tool show --scope=namespaced --without-verbs=create,update,patch,delete,del
 	flags := cmd.Flags()
 
 	flags.StringVarP(&clusterContext, "cluster-context", "c", "", "Cluster.use 'kubectl config get-contexts' to list available contexts")
-	flags.StringVar(&name, "name", "", "Name of Role/ClusterRole")
-	flags.StringVarP(&namespace, "namespace", "n", "", "Namespace of Role/ClusterRole")
+	flags.StringVar(&name, "name", "custom-cluster-role", "Name of Role/ClusterRole")
+	flags.StringVarP(&namespace, "namespace", "n", "myappnamespace", "Namespace of Role/ClusterRole")
 	flags.StringVarP(&scope, "scope", "", "all", "Filter by resource scope. Valid values are: 'cluster' | 'namespaced' | 'all' ")
 	flags.StringSliceVar(&forGroups, "for-groups", []string{"*"}, "Comma separated list of API groups we would like to show the permissions")
 	flags.StringSliceVar(&withVerb, "with-verbs", []string{"*"}, "Comma separated list of verbs to include. To include all use '*'")


### PR DESCRIPTION
Apologies for the delay in re-opening this pull request. This would add only the following functionality to `rbac-tool gen` and `rbac-tool show` commands. While the intent of `rbac-tool show` is not necessarily to generate clusterroles/roles, it made sense to include the flags both places since they call the same `generateRole` function.

This will also maintain the same default role names and namespace for users that are not passing the new flags.

## Generate Role:

```bash
rbac-tool gen \
  --allowed-groups ,apps \
  --generated-type Role \
  --name foo \
  --namespace bar \
  --annotations argocd.argoproj.io/sync-wave=2,rbac.authorization.kubernetes.io/autoupdate=true
```

### Output:

```yaml
apiVersion: rbac.authorization.k8s.io/v1
kind: Role
metadata:
  annotations:
    argocd.argoproj.io/sync-wave: "2"
    rbac.authorization.kubernetes.io/autoupdate: "true"
  creationTimestamp: null
  name: foo
  namespace: bar
rules:
...
```

## Generate ClusterRole:

```bash
rbac-tool gen \
  --allowed-groups ,apps \
  --name foo \     
  --annotations argocd.argoproj.io/sync-wave=2,rbac.authorization.kubernetes.io/autoupdate=true
```

### Output:

```yaml
apiVersion: rbac.authorization.k8s.io/v1
kind: ClusterRole
metadata:
  annotations:
    argocd.argoproj.io/sync-wave: "2"
    rbac.authorization.kubernetes.io/autoupdate: "true"
  creationTimestamp: null
  name: foo
```

Thanks again! 😄 