### PR TITLE
docs: fix typo in visualize command doc/help

### DIFF
--- a/cmd/visualize_cmd.go
+++ b/cmd/visualize_cmd.go
@@ -2,7 +2,6 @@ package cmd
 
 import (
 	"fmt"
-
 	"github.com/alcideio/rbac-tool/pkg/utils"
 	"github.com/alcideio/rbac-tool/pkg/visualize"
 	"github.com/fatih/color"

--- a/cmd/visualize_cmd.go
+++ b/cmd/visualize_cmd.go
@@ -2,6 +2,7 @@ package cmd
 
 import (
 	"fmt"
+
 	"github.com/alcideio/rbac-tool/pkg/utils"
 	"github.com/alcideio/rbac-tool/pkg/visualize"
 	"github.com/fatih/color"
@@ -76,7 +77,7 @@ rbac-tool viz --include-pods-only
 	flags.StringVar(&opts.Outformat, "outformat", "html", "Output format: dot or html")
 	flags.StringVar(&opts.IncludedNamespaces, "include-namespaces", "*", "Comma-delimited list of namespaces to include in the visualization")
 	flags.StringVar(&opts.IncludeSubjectsRegex, "include-subjects", ".*", "A regular expression to limit the subjects we visualize")
-	flags.StringVar(&opts.ExcludedNamespaces, "exclude-namespaces", "kube-system", "Comma-delimited list of namespaces to include in the visualization")
+	flags.StringVar(&opts.ExcludedNamespaces, "exclude-namespaces", "kube-system", "Comma-delimited list of namespaces to exclude from the visualization")
 
 	flags.BoolVar(&opts.ShowPodsOnly, "include-pods-only", false, "Show the graph only for service accounts used by Pods")
 


### PR DESCRIPTION
closes #115 